### PR TITLE
add is_global

### DIFF
--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from aatoolbox.config.countryconfig import CountryConfig
 from aatoolbox.config.pathconfig import PathConfig
 
+_GLOBAL_DIR = "glb"
+
 
 class DataSource:
     """
@@ -25,19 +27,27 @@ class DataSource:
         country_config: CountryConfig,
         module_base_dir: str,
         is_public: bool = False,
+        is_global: bool = False,
     ):
 
         self._country_config = country_config
         self._module_base_dir = module_base_dir
         self._path_config = PathConfig()
         self._raw_base_dir = self._get_base_dir(
-            is_public=is_public, is_raw=True
+            is_public=is_public,
+            is_global=is_global,
+            is_raw=True,
         )
         self._processed_base_dir = self._get_base_dir(
-            is_public=is_public, is_raw=False
+            is_public=is_public, is_global=is_global, is_raw=False
         )
 
-    def _get_base_dir(self, is_public: bool, is_raw: bool) -> Path:
+    def _get_base_dir(
+        self,
+        is_public: bool,
+        is_raw: bool,
+        is_global: bool,
+    ) -> Path:
         permission_dir = (
             self._path_config.public
             if is_public
@@ -46,10 +56,13 @@ class DataSource:
         state_dir = (
             self._path_config.raw if is_raw else self._path_config.processed
         )
+        region_dir = (
+            self._country_config.iso3 if not is_global else _GLOBAL_DIR
+        )
         return (
             self._path_config.base_path
             / permission_dir
             / state_dir
-            / self._country_config.iso3
+            / region_dir
             / self._module_base_dir
         )

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -27,7 +27,6 @@ class DataSource:
         country_config: CountryConfig,
         module_base_dir: str,
         is_public: bool = False,
-        is_global: bool = False,
     ):
 
         self._country_config = country_config
@@ -35,19 +34,32 @@ class DataSource:
         self._path_config = PathConfig()
         self._raw_base_dir = self._get_base_dir(
             is_public=is_public,
-            is_global=is_global,
             is_raw=True,
         )
         self._processed_base_dir = self._get_base_dir(
-            is_public=is_public, is_global=is_global, is_raw=False
+            is_public=is_public, is_raw=False
         )
 
     def _get_base_dir(
         self,
         is_public: bool,
         is_raw: bool,
-        is_global: bool,
+        is_global: bool = False,
     ) -> Path:
+        """
+        Define the base_dir.
+
+        Parameters
+        ----------
+        is_public: bool
+            Whether the dataset is public or private. Determines top-level
+            directory structure.
+        is_raw: bool
+            Whether the dataset is raw or processed
+        is_global: bool
+            Whether the dataset is global (or regional) or specific to the
+            iso3
+        """
         permission_dir = (
             self._path_config.public
             if is_public


### PR DESCRIPTION
Adding an `is_global` par to the DataSource class to enable loading from global datasources.

Not sure what to do when the raw datasource is in global and we process it to only contain country data (or maybe we shouldn't do that anyway?) 