### PR TITLE
Fixes to GeoBoundingBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 
 - `DataSource` is now an abstract base class with required `download`, `process`
   and `load` methods
+- `GeoBoundingBox.round` returns `GeoBoundingBox` instance (instead of being in place)
 
 ### Removed
 
@@ -33,7 +34,7 @@ and this project adheres to
   (using tags instead)
 - HDX API now uses "prod" server, and version >= 5.5.8 to avoid download error
 - COD AB dataset URLs on HDX are standardized
-- GeoBoundingBox won't round twice and won't allow north < south or east < west
+- `GeoBoundingBox` won't allow north < south or east < west
 
 ## [0.3.1] - 2022-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
   (using tags instead)
 - HDX API now uses "prod" server, and version >= 5.5.8 to avoid download error
 - COD AB dataset URLs on HDX are standardized
+- GeoBoundingBox won't round twice and won't allow north < south or east < west
 
 ## [0.3.1] - 2022-01-06
 

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -61,10 +61,7 @@ class _IriForecast(DataSource):
         # non-rounded coordinates can be given to the URL which then
         # automatically rounds them, but for file saving we prefer to do
         # this ourselves
-        # TODO: We should probably make a copy of this as it's being
-        #  passed directly by the user
-        geo_bounding_box.round_coords(round_val=1, offset_val=0)
-        self._geobb = geo_bounding_box
+        self._geobb = geo_bounding_box.round_coords(round_val=1, offset_val=0)
         self._forecast_type = forecast_type
 
     def download(

--- a/src/aatoolbox/utils/geoboundingbox.py
+++ b/src/aatoolbox/utils/geoboundingbox.py
@@ -44,22 +44,22 @@ class GeoBoundingBox:
         self._rounded: bool = False
 
     @property
-    def north(self):
+    def north(self) -> float:
         """Get the northern latitude boundary of the area (degrees)."""
         return float(self._north)
 
     @property
-    def south(self):
+    def south(self) -> float:
         """Get the southern latitude boundary of the area (degrees)."""
         return float(self._south)
 
     @property
-    def east(self):
+    def east(self) -> float:
         """Get the eastern longitude boundary of the area (degrees)."""
         return float(self._east)
 
     @property
-    def west(self):
+    def west(self) -> float:
         """Get the western longitude boundary of the area (degrees)."""
         return float(self._west)
 

--- a/src/aatoolbox/utils/geoboundingbox.py
+++ b/src/aatoolbox/utils/geoboundingbox.py
@@ -41,7 +41,6 @@ class GeoBoundingBox:
         self._south = Decimal(south)
         self._east = Decimal(east)
         self._west = Decimal(west)
-        self._rounded: bool = False
 
     @property
     def north(self) -> float:
@@ -71,14 +70,20 @@ class GeoBoundingBox:
         )
 
     @classmethod
-    def from_shape(cls, shape: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+    def from_shape(
+        cls, shape: Union[gpd.GeoSeries, gpd.GeoDataFrame]
+    ) -> "GeoBoundingBox":
         """
-        Create `GeoBoundingBox` from a geopandas object.
+        Create ``GeoBoundingBox`` from a geopandas object.
 
         Parameters
         ----------
         shape : geopandas.GeoSeries, geopandas.GeoDataFrame
             A shape whose bounds will be retrieved
+
+        Returns
+        -------
+        ``GeoBoundingBox`` from the total bounds of the ``GeoDataFrame``
 
         Examples
         --------
@@ -97,7 +102,7 @@ class GeoBoundingBox:
         self,
         offset_val: float = 0.0,
         round_val: Union[int, float] = 1,
-    ):
+    ) -> "GeoBoundingBox":
         """
         Round the bounding box coordinates.
 
@@ -113,13 +118,13 @@ class GeoBoundingBox:
         round_val : int or float, default = 1
             Rounds to the nearest round_val. Can be an int for integer
             rounding or float for decimal rounding. If 1, round to integers.
+
+        Returns
+        -------
+        ``GeoBoundingBox`` instance with rounded and offset coordinates
         """
         # TODO: add examples above
-        # Don't round if already rounded
-        if self._rounded:
-            logger.debug("Coordinates have already been rounded, skipping")
-            return
-        # Make everything a decimal
+        new_coords = {}
         for direction in ["north", "west", "south", "east"]:
             coord = getattr(self, f"_{direction}")
             if direction in ("north", "east"):
@@ -131,8 +136,8 @@ class GeoBoundingBox:
             rounded_coord = function(coord / Decimal(round_val)) * Decimal(
                 round_val
             ) + offset_factor * Decimal(offset_val)
-            setattr(self, f"_{direction}", rounded_coord)  # noqa: FKA01
-        self._rounded = True
+            new_coords[direction] = float(rounded_coord)
+        return GeoBoundingBox(**new_coords)
 
     def get_filename_repr(self, p: int = 0) -> str:
         """

--- a/src/aatoolbox/utils/geoboundingbox.py
+++ b/src/aatoolbox/utils/geoboundingbox.py
@@ -5,10 +5,13 @@ It is possible to create an ``GeoBoundingBox`` object either from
 north, south, east, west coordinates,
 or from a shapefile that has been read in with geopandas.
 """
+import logging
 from typing import Union
 
 import geopandas as gpd
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class GeoBoundingBox:
@@ -31,6 +34,7 @@ class GeoBoundingBox:
         self.south = south
         self.east = east
         self.west = west
+        self._rounded: bool = False
 
     def __repr__(self):
         """Print bounding box string."""
@@ -70,17 +74,24 @@ class GeoBoundingBox:
         """
         Round the bounding box coordinates.
 
-        Rounding is always done outside the original bounding box.
-        I.e. the resulting bounding box is always equal or larger
-        than the original bounding box.
+        Rounding is always done outside the original bounding box,
+        i.e. the resulting bounding box is always equal or larger
+        than the original bounding box. Rounding can only be done once
+        per instance.
 
         Parameters
         ----------
         offset_val : float, default = 0.0
             Offset the coordinates by this factor.
-        round_val : int, default = 1
-            The decimal to round to. If 1, round to integers
+        round_val : int or float, default = 1
+            Rounds to the nearest round_val. Can be an int for integer
+            rounding or float for decimal rounding. If 1, round to integers.
         """
+        # TODO: add examples above
+        # Don't round if already rounded
+        if self._rounded:
+            logger.debug("Coordinates have already been rounded, skipping")
+            return
         for direction in ["north", "west", "south", "east"]:
             coord = getattr(self, direction)
             if direction in ("north", "east"):
@@ -95,6 +106,7 @@ class GeoBoundingBox:
                 + offset_factor * offset_val
             )
             setattr(self, direction, rounded_coord)  # noqa: FKA01
+        self._rounded = True
 
     def get_filename_repr(self, p: int = 0) -> str:
         """

--- a/src/aatoolbox/utils/geoboundingbox.py
+++ b/src/aatoolbox/utils/geoboundingbox.py
@@ -6,12 +6,14 @@ north, south, east, west coordinates,
 or from a shapefile that has been read in with geopandas.
 """
 import logging
+from decimal import Decimal, getcontext
 from typing import Union
 
 import geopandas as gpd
 import numpy as np
 
 logger = logging.getLogger(__name__)
+getcontext().prec = 5  # Assuming we won't need higher than this!
 
 
 class GeoBoundingBox:
@@ -30,11 +32,36 @@ class GeoBoundingBox:
     """
 
     def __init__(self, north: float, south: float, east: float, west: float):
-        self.north = north
-        self.south = south
-        self.east = east
-        self.west = west
+        if north < south or east < west:
+            raise AttributeError(
+                "Periodic boundary conditions not supported. "
+                "North must be > South, and East must be > West."
+            )
+        self._north = Decimal(north)
+        self._south = Decimal(south)
+        self._east = Decimal(east)
+        self._west = Decimal(west)
         self._rounded: bool = False
+
+    @property
+    def north(self):
+        """Get the northern latitude boundary of the area (degrees)."""
+        return float(self._north)
+
+    @property
+    def south(self):
+        """Get the southern latitude boundary of the area (degrees)."""
+        return float(self._south)
+
+    @property
+    def east(self):
+        """Get the eastern longitude boundary of the area (degrees)."""
+        return float(self._east)
+
+    @property
+    def west(self):
+        """Get the western longitude boundary of the area (degrees)."""
+        return float(self._west)
 
     def __repr__(self):
         """Print bounding box string."""
@@ -92,20 +119,19 @@ class GeoBoundingBox:
         if self._rounded:
             logger.debug("Coordinates have already been rounded, skipping")
             return
+        # Make everything a decimal
         for direction in ["north", "west", "south", "east"]:
-            coord = getattr(self, direction)
+            coord = getattr(self, f"_{direction}")
             if direction in ("north", "east"):
                 function = np.ceil.__call__  # needed for mypy
-                offset_factor = 1
+                offset_factor = Decimal(1)
             elif direction in ("south", "west"):
                 function = np.floor.__call__  # needed for mypy
-                offset_factor = -1
-
-            rounded_coord = (
-                function(coord / round_val) * round_val
-                + offset_factor * offset_val
-            )
-            setattr(self, direction, rounded_coord)  # noqa: FKA01
+                offset_factor = Decimal(-1)
+            rounded_coord = function(coord / Decimal(round_val)) * Decimal(
+                round_val
+            ) + offset_factor * Decimal(offset_val)
+            setattr(self, f"_{direction}", rounded_coord)  # noqa: FKA01
         self._rounded = True
 
     def get_filename_repr(self, p: int = 0) -> str:

--- a/tests/datasources/test_iri.py
+++ b/tests/datasources/test_iri.py
@@ -20,7 +20,7 @@ FAKE_IRI_AUTH = "FAKE_IRI_AUTH"
 @pytest.fixture
 def mock_iri(mock_country_config):
     """Create IRI class with mock country config."""
-    geo_bounding_box = GeoBoundingBox(north=6, south=3.2, east=-2, west=3)
+    geo_bounding_box = GeoBoundingBox(north=6, south=3.2, east=2, west=-3)
 
     def _mock_iri(prob_forecast: bool = True):
         if prob_forecast:
@@ -72,14 +72,14 @@ def test_download_call_prob(mock_download):
     assert url == (
         "https://iridl.ldeo.columbia.edu/SOURCES/.IRI/.FD/"
         ".NMME_Seasonal_Forecast/"
-        ".Precipitation_ELR/.prob/X/%283.0%29%28-2.0%29RANGEEDGES/"
+        ".Precipitation_ELR/.prob/X/%28-3.0%29%282.0%29RANGEEDGES/"
         "Y/%286.0%29%283.0%29RANGEEDGES/data.nc"
     )
 
     assert filepath == (
         Path(FAKE_AA_DATA_DIR) / f"private/raw/{ISO3}/{MODULE_BASENAME}/"
         f"abc_iri_forecast_seasonal_precipitation_"
-        f"tercile_prob_Np6Sp3Em2Wp3.nc"
+        f"tercile_prob_Np6Sp3Ep2Wm3.nc"
     )
 
 
@@ -89,14 +89,14 @@ def test_download_call_dominant(mock_download):
     assert url == (
         "https://iridl.ldeo.columbia.edu/SOURCES/.IRI/.FD/"
         ".NMME_Seasonal_Forecast/"
-        ".Precipitation_ELR/.dominant/X/%283.0%29%28-2.0%29RANGEEDGES/"
+        ".Precipitation_ELR/.dominant/X/%28-3.0%29%282.0%29RANGEEDGES/"
         "Y/%286.0%29%283.0%29RANGEEDGES/data.nc"
     )
 
     assert filepath == (
         Path(FAKE_AA_DATA_DIR) / f"private/raw/{ISO3}/{MODULE_BASENAME}/"
         f"abc_iri_forecast_seasonal_"
-        f"precipitation_tercile_dominant_Np6Sp3Em2Wp3.nc"
+        f"precipitation_tercile_dominant_Np6Sp3Ep2Wm3.nc"
     )
 
 
@@ -132,7 +132,7 @@ def test_process(mocker, mock_iri):
     assert processed_path == (
         Path(FAKE_AA_DATA_DIR) / f"private/processed/{ISO3}/{MODULE_BASENAME}/"
         f"{ISO3}_iri_forecast_seasonal_precipitation_"
-        f"tercile_prob_Np6Sp3Em2Wp3.nc"
+        f"tercile_prob_Np6Sp3Ep2Wm3.nc"
     )
 
     da_processed = xr.load_dataset(processed_path)
@@ -187,7 +187,7 @@ def test_iri_load(mocker, mock_xr_load_dataset, mock_iri):
                 Path(FAKE_AA_DATA_DIR)
                 / f"private/processed/{ISO3}/{MODULE_BASENAME}/"
                 f"{ISO3}_iri_forecast_seasonal_precipitation_"
-                f"tercile_prob_Np6Sp3Em2Wp3.nc"
+                f"tercile_prob_Np6Sp3Ep2Wm3.nc"
             ),
         ]
     )

--- a/tests/test_geoboundingbox.py
+++ b/tests/test_geoboundingbox.py
@@ -1,4 +1,5 @@
 """Tests for the CDS GeoBoundingBox module."""
+import pytest
 from geopandas import GeoSeries
 from shapely.geometry import Polygon
 
@@ -27,12 +28,19 @@ def test_geoboundingbox_offset_coords():
 
 def test_geoboundingbox_round_and_offset_coords():
     """Test that coordinates are correctly rounded and offset."""
-    geobb = GeoBoundingBox(north=0.96, south=-2.2, east=3.6, west=-4.0)
+    geobb = GeoBoundingBox(north=1.05, south=-2.2, east=3.6, west=-4.0)
     geobb.round_coords(round_val=0.1, offset_val=0.05)
-    assert geobb.north == 1.05
+    assert geobb.north == 1.15
     assert geobb.south == -2.25
     assert geobb.east == 3.65
     assert geobb.west == -4.05
+
+
+def test_geoboundingbox_relative_coords():
+    """Test that doesn't allow north < south and east < west."""
+    with pytest.raises(AttributeError):
+        GeoBoundingBox(north=1, south=2, east=0, west=0)
+        GeoBoundingBox(north=0, south=0, east=1, west=2)
 
 
 def test_geoboundingbox_filename():

--- a/tests/test_geoboundingbox.py
+++ b/tests/test_geoboundingbox.py
@@ -8,8 +8,9 @@ from aatoolbox.utils.geoboundingbox import GeoBoundingBox
 
 def test_geoboundingbox_round_coords():
     """Test that coordinates are correctly rounded."""
-    geobb = GeoBoundingBox(north=1.5, south=-2.2, east=3.6, west=-4.0)
-    geobb.round_coords(round_val=0.5)
+    geobb = GeoBoundingBox(
+        north=1.5, south=-2.2, east=3.6, west=-4.0
+    ).round_coords(round_val=0.5)
     assert geobb.north == 1.5
     assert geobb.south == -2.5
     assert geobb.east == 4.0
@@ -18,8 +19,11 @@ def test_geoboundingbox_round_coords():
 
 def test_geoboundingbox_offset_coords():
     """Test that coordinates are correctly offset."""
-    geobb = GeoBoundingBox(north=1.05, south=-2.2, east=3.6, west=-4.0)
-    geobb.round_coords(offset_val=0.4)  # default round val of 1
+    geobb = GeoBoundingBox(
+        north=1.05, south=-2.2, east=3.6, west=-4.0
+    ).round_coords(
+        offset_val=0.4
+    )  # default round val of 1
     assert geobb.north == 2.4
     assert geobb.south == -3.4
     assert geobb.east == 4.4
@@ -28,8 +32,9 @@ def test_geoboundingbox_offset_coords():
 
 def test_geoboundingbox_round_and_offset_coords():
     """Test that coordinates are correctly rounded and offset."""
-    geobb = GeoBoundingBox(north=1.05, south=-2.2, east=3.6, west=-4.0)
-    geobb.round_coords(round_val=0.1, offset_val=0.05)
+    geobb = GeoBoundingBox(
+        north=1.05, south=-2.2, east=3.6, west=-4.0
+    ).round_coords(round_val=0.1, offset_val=0.05)
     assert geobb.north == 1.15
     assert geobb.south == -2.25
     assert geobb.east == 3.65
@@ -58,12 +63,3 @@ def test_geoboundingbox_from_shape():
     assert geobb.south == s
     assert geobb.east == e
     assert geobb.west == w
-
-
-def test_dont_double_round():
-    """Test that round is not called twice."""
-    geobb = GeoBoundingBox(north=1.4, south=1, east=1, west=1)
-    geobb.round_coords(round_val=0.5)
-    assert geobb.north == 1.5
-    geobb.round_coords(round_val=1)
-    assert geobb.north == 1.5

--- a/tests/test_geoboundingbox.py
+++ b/tests/test_geoboundingbox.py
@@ -6,13 +6,33 @@ from aatoolbox.utils.geoboundingbox import GeoBoundingBox
 
 
 def test_geoboundingbox_round_coords():
-    """Test that coordinates are correctly rounded and offset."""
-    geobb = GeoBoundingBox(north=1.05, south=-2.2, east=3.6, west=-4)
-    geobb.round_coords(offset_val=0.4)
+    """Test that coordinates are correctly rounded."""
+    geobb = GeoBoundingBox(north=1.5, south=-2.2, east=3.6, west=-4.0)
+    geobb.round_coords(round_val=0.5)
+    assert geobb.north == 1.5
+    assert geobb.south == -2.5
+    assert geobb.east == 4.0
+    assert geobb.west == -4.0
+
+
+def test_geoboundingbox_offset_coords():
+    """Test that coordinates are correctly offset."""
+    geobb = GeoBoundingBox(north=1.05, south=-2.2, east=3.6, west=-4.0)
+    geobb.round_coords(offset_val=0.4)  # default round val of 1
     assert geobb.north == 2.4
     assert geobb.south == -3.4
     assert geobb.east == 4.4
     assert geobb.west == -4.4
+
+
+def test_geoboundingbox_round_and_offset_coords():
+    """Test that coordinates are correctly rounded and offset."""
+    geobb = GeoBoundingBox(north=0.96, south=-2.2, east=3.6, west=-4.0)
+    geobb.round_coords(round_val=0.1, offset_val=0.05)
+    assert geobb.north == 1.05
+    assert geobb.south == -2.25
+    assert geobb.east == 3.65
+    assert geobb.west == -4.05
 
 
 def test_geoboundingbox_filename():
@@ -30,3 +50,12 @@ def test_geoboundingbox_from_shape():
     assert geobb.south == s
     assert geobb.east == e
     assert geobb.west == w
+
+
+def test_dont_double_round():
+    """Test that round is not called twice."""
+    geobb = GeoBoundingBox(north=1.4, south=1, east=1, west=1)
+    geobb.round_coords(round_val=0.5)
+    assert geobb.north == 1.5
+    geobb.round_coords(round_val=1)
+    assert geobb.north == 1.5


### PR DESCRIPTION
I had started implementing these in the GloFAS branch, since that is delayed I thought better make a separate PR. The changes are:

- Rounding now returns new instance of GoeBoundingBox
- Use `Decimal` type internally. This is to fix some rounding errors I found with the GloFAS coordinates, e.g. I was getting 1.1500000000000001 after the rounding step, which was getting passed to the API. Probably not a huge deal but better to fix this I think.
- Don't allow the user to pass North < South or East < West. @Tinkaa when I implemented this I had to change the IRI tests - was this intentional on your part, do we not want this restriction? 