### PR TITLE
Implement kalendar module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Changed
 ~~~~~~~
 
 - tox configuration moved to ``setup.cfg`` from ``tox.ini``
-
+- ``kalendar`` library used for ``dekad`` and ``pentad`` classes
 
 [1.0.1] - 2023-02-03
 --------------------

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -272,6 +272,8 @@ jsonschema==4.17.3
     #   -r requirements/requirements.txt
     #   frictionless
     #   tableschema-to-template
+kalendar==0.1.1
+    # via -r requirements/requirements.txt
 libhxl==4.27.3
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -147,6 +147,8 @@ jsonschema==4.17.3
     # via
     #   frictionless
     #   tableschema-to-template
+kalendar==0.1.1
+    # via ocha-anticipy (setup.cfg)
 libhxl==4.27.3
     # via hdx-python-country
 locket==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     geopandas
     hdx-python-api>=5.6.4
     hdx-python-country
+    kalendar>=0.1.1
     netCDF4
     numpy
     pydantic

--- a/src/ochanticipy/datasources/usgs/ndvi_products.py
+++ b/src/ochanticipy/datasources/usgs/ndvi_products.py
@@ -13,6 +13,8 @@ import logging
 from datetime import date
 from typing import Tuple, Union
 
+from kalendar import Dekad
+
 from ochanticipy.config.countryconfig import CountryConfig
 from ochanticipy.datasources.usgs.ndvi_base import _UsgsNdvi
 
@@ -37,15 +39,16 @@ class UsgsNdviSmoothed(_UsgsNdvi):
         Start date. Can be passed as a ``datetime.date``
         object or a data string in ISO8601 format, and
         the relevant dekad will be determined. Or pass
-        directly as year-dekad tuple, e.g. (2020, 1).
-        If ``None``, ``start_date`` is set to earliest
-        date with data: 2002, dekad 19.
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``start_date``
+        is set to earliest date with data: 2002, dekad 19.
     end_date : _DATE_TYPE, default = None
         End date. Can be passed as a ``datetime.date``
-        object and the relevant dekad will be determined,
-        as a date string in ISO8601 format, or as a
-        year-dekad tuple, i.e. (2020, 1). If ``None``,
-        ``end_date`` is set to ``date.today()``.
+        object or a data string in ISO8601 format, and
+        the relevant dekad will be determined. Or pass
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``end_date`` is
+        set to earliest ``date.today``.
 
     Examples
     --------
@@ -76,8 +79,8 @@ class UsgsNdviSmoothed(_UsgsNdvi):
     def __init__(
         self,
         country_config: CountryConfig,
-        start_date: Union[date, str, Tuple[int, int], None] = None,
-        end_date: Union[date, str, Tuple[int, int], None] = None,
+        start_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+        end_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
     ):
         super().__init__(
             country_config=country_config,
@@ -104,15 +107,16 @@ class UsgsNdviPctMedian(_UsgsNdvi):
         Start date. Can be passed as a ``datetime.date``
         object or a data string in ISO8601 format, and
         the relevant dekad will be determined. Or pass
-        directly as year-dekad tuple, e.g. (2020, 1).
-        If ``None``, ``start_date`` is set to earliest
-        date with data: 2002, dekad 19.
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``start_date``
+        is set to earliest date with data: 2002, dekad 19.
     end_date : _DATE_TYPE, default = None
         End date. Can be passed as a ``datetime.date``
-        object and the relevant dekad will be determined,
-        as a date string in ISO8601 format, or as a
-        year-dekad tuple, i.e. (2020, 1). If ``None``,
-        ``end_date`` is set to ``date.today()``.
+        object or a data string in ISO8601 format, and
+        the relevant dekad will be determined. Or pass
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``end_date`` is
+        set to earliest ``date.today``.
 
     Examples
     --------
@@ -143,8 +147,8 @@ class UsgsNdviPctMedian(_UsgsNdvi):
     def __init__(
         self,
         country_config: CountryConfig,
-        start_date: Union[date, str, Tuple[int, int], None] = None,
-        end_date: Union[date, str, Tuple[int, int], None] = None,
+        start_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+        end_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
     ):
         super().__init__(
             country_config=country_config,
@@ -174,15 +178,16 @@ class UsgsNdviMedianAnomaly(_UsgsNdvi):
         Start date. Can be passed as a ``datetime.date``
         object or a data string in ISO8601 format, and
         the relevant dekad will be determined. Or pass
-        directly as year-dekad tuple, e.g. (2020, 1).
-        If ``None``, ``start_date`` is set to earliest
-        date with data: 2002, dekad 19.
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``start_date``
+        is set to earliest date with data: 2002, dekad 19.
     end_date : _DATE_TYPE, default = None
         End date. Can be passed as a ``datetime.date``
-        object and the relevant dekad will be determined,
-        as a date string in ISO8601 format, or as a
-        year-dekad tuple, i.e. (2020, 1). If ``None``,
-        ``end_date`` is set to ``date.today()``.
+        object or a data string in ISO8601 format, and
+        the relevant dekad will be determined. Or pass
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        ``kalendar.Dekad``. If ``None``, ``end_date`` is
+        set to earliest ``date.today``.
 
     Examples
     --------
@@ -213,8 +218,8 @@ class UsgsNdviMedianAnomaly(_UsgsNdvi):
     def __init__(
         self,
         country_config: CountryConfig,
-        start_date: Union[date, str, Tuple[int, int], None] = None,
-        end_date: Union[date, str, Tuple[int, int], None] = None,
+        start_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+        end_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
     ):
         super().__init__(
             country_config=country_config,
@@ -244,15 +249,16 @@ class UsgsNdviYearDifference(_UsgsNdvi):
         Start date. Can be passed as a ``datetime.date``
         object or a data string in ISO8601 format, and
         the relevant dekad will be determined. Or pass
-        directly as year-dekad tuple, e.g. (2020, 1).
-        If ``None``, ``start_date`` is set to earliest
-        date with data: 2002, dekad 19.
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        `kalendar.Dekad`. If ``None``, ``start_date``
+        is set to earliest date with data: 2002, dekad 19.
     end_date : _DATE_TYPE, default = None
         End date. Can be passed as a ``datetime.date``
-        object and the relevant dekad will be determined,
-        as a date string in ISO8601 format, or as a
-        year-dekad tuple, i.e. (2020, 1). If ``None``,
-        ``end_date`` is set to ``date.today()``.
+        object or a data string in ISO8601 format, and
+        the relevant dekad will be determined. Or pass
+        directly as year-dekad tuple, e.g. (2020, 1) or
+        `kalendar.Dekad`. If ``None``, ``end_date`` is
+        set to earliest ``date.today``.
 
     Examples
     --------
@@ -283,8 +289,8 @@ class UsgsNdviYearDifference(_UsgsNdvi):
     def __init__(
         self,
         country_config: CountryConfig,
-        start_date: Union[date, str, Tuple[int, int], None] = None,
-        end_date: Union[date, str, Tuple[int, int], None] = None,
+        start_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+        end_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
     ):
         super().__init__(
             country_config=country_config,

--- a/src/ochanticipy/utils/dates.py
+++ b/src/ochanticipy/utils/dates.py
@@ -1,8 +1,9 @@
 """Functions for dealing with dates."""
 
-import itertools
 from datetime import date
-from typing import List, Tuple, Union, cast
+from typing import List, Tuple, Union, cast, overload
+
+from kalendar import Dekad, Pentad
 
 
 def get_date_from_user_input(input_date: Union[date, str]) -> date:
@@ -40,10 +41,31 @@ def get_date_from_user_input(input_date: Union[date, str]) -> date:
     return input_date
 
 
-def get_dekadal_date(
-    input_date: Union[date, str, Tuple[int, int], None],
-    default_date: Union[date, str, Tuple[int, int], None] = None,
-) -> Tuple[int, int]:
+@overload
+def get_kalendar_date(
+    kalendar_class: Dekad,
+    input_date: Union[date, str, Tuple[int, int], Dekad, None],
+    default_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+) -> Dekad:
+    ...
+
+
+@overload
+def get_kalendar_date(  # type: ignore
+    kalendar_class: Pentad,
+    input_date: Union[date, str, Tuple[int, int], Pentad, None],
+    default_date: Union[date, str, Tuple[int, int], Pentad, None] = None,
+) -> Pentad:
+    ...
+
+
+def get_kalendar_date(
+    kalendar_class: Union[Dekad, Pentad],
+    input_date: Union[date, str, Tuple[int, int], Dekad, Pentad, None],
+    default_date: Union[
+        date, str, Tuple[int, int], Dekad, Pentad, None
+    ] = None,
+) -> Union[Dekad, Pentad]:
     """Calculate dekadal date from general input.
 
     Processes input ``input_date`` and returns two
@@ -57,144 +79,43 @@ def get_dekadal_date(
     if input_date is None and default_date is not None:
         input_date = default_date
 
-    # convert date to various values
-    if not isinstance(input_date, (str, date)):
-        input_tuple = cast(Tuple[int, int], input_date)
-        if len(input_tuple) == 2:
-            year, dekad = input_tuple
-            # assert year-dekad values appropriate, not too strict
-            if year < 1000 or year > 9999 or dekad < 1 or dekad > 36:
-                raise ValueError(
-                    f"(year, dekad) tuple ({year}, {dekad}) invalid. "
-                    "Year should be a 4-digit year and dekad between "
-                    "1 and 36."
-                )
-
-        else:
-            raise ValueError(
-                (
-                    "`date` values for dekadal data "
-                    "should be passed in as "
-                    "`datetime.date` objects, tuples "
-                    "of `(year, dekad)` format, or "
-                    "ISO8601 date strings."
-                )
-            )
-
+    if isinstance(input_date, kalendar_class):
+        return input_date
+    if isinstance(input_date, date):
+        return kalendar_class.fromdate(input_date)
+    if isinstance(input_date, str):
+        return kalendar_class.fromisoformat(input_date)
     else:
-        input_as_date = get_date_from_user_input(input_date)
-        year, dekad = date_to_dekad(input_as_date)
+        input_tuple = cast(Tuple[int, int], input_date)
+        try:
+            return Dekad(*input_tuple)
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                "`date` values for dekad or pentad date "
+                "should be passed in as "
+                "`datetime.date` or `kalendar.Dekad/Pentad` "
+                "objects, tuples "
+                "of `(year, dekad)` format, or "
+                "ISO8601 date strings."
+            ) from e
 
-    return year, dekad
+
+@overload
+def kalendar_range(x: Dekad, y: Dekad) -> List[Dekad]:
+    ...
 
 
-def dekad_to_date(dekad: Tuple[int, int]) -> date:
-    """Compute date from dekad and year.
+@overload
+def kalendar_range(x: Pentad, y: Pentad) -> List[Pentad]:  # type: ignore
+    ...
 
-    Date computed from dekad and year in
-    datetime object, corresponding to
-    first day of the dekad. This
-    is based on the
-    `common dekadal definition
-    <http://iridl.ldeo.columbia.edu/maproom/Food_Security/Locusts/Regional/Dekadal_Rainfall/index.html>`_
-    of the 1st and 2nd dekad of a month
-    being the first 10 day periods, and
-    the 3rd dekad being the remaining
-    days within that month.
+
+def kalendar_range(
+    x: Union[Dekad, Pentad], y: Union[Dekad, Pentad]
+) -> List[Union[Dekad, Pentad]]:
+    """Expand between dekads and pentads.
+
+    Takes input dekad or pentad and returns a list
+    of dekads/pentads.
     """
-    year = dekad[0]
-    month = ((dekad[1] - 1) // 3) + 1
-    day = 10 * ((dekad[1] - 1) % 3) + 1
-    return date(year=year, month=month, day=day)
-
-
-def date_to_dekad(date_obj: date) -> Tuple[int, int]:
-    """Compute dekad and year from date.
-
-    Dekad computed from date. This
-    is based on the
-    `common dekadal definition
-    <http://iridl.ldeo.columbia.edu/maproom/Food_Security/Locusts/Regional/Dekadal_Rainfall/index.html>`_
-    of the 1st and 2nd dekad of a month
-    being the first 10 day periods, and
-    the 3rd dekad being the remaining
-    days within that month.
-    """
-    year = date_obj.year
-    dekad = min((date_obj.day - 1) // 10, 2) + ((date_obj.month - 1) * 3) + 1
-    return (year, dekad)
-
-
-def compare_dekads_lt(
-    dekad1: Tuple[int, int], dekad2: Tuple[int, int]
-) -> bool:
-    """Is year1/dekad1 less than year2/dekad2.
-
-    Compare two pairs of years and dekads,
-    that the first pair are less than the
-    second pair.
-    """
-    y1, d1 = dekad1
-    y2, d2 = dekad2
-    return y1 < y2 or ((y1 == y2) and (d1 < d2))
-
-
-def compare_dekads_lte(
-    dekad1: Tuple[int, int], dekad2: Tuple[int, int]
-) -> bool:
-    """Is year1/dekad1 less than or equal to year2/dekad2.
-
-    Compare two pairs of years and dekads,
-    that the first pair are less than or
-    equal to the second pair.
-    """
-    y1, d1 = dekad1
-    y2, d2 = dekad2
-    return y1 < y2 or ((y1 == y2) and (d1 <= d2))
-
-
-def compare_dekads_gt(
-    dekad1: Tuple[int, int], dekad2: Tuple[int, int]
-) -> bool:
-    """Is year1/dekad1 greater than year2/dekad2.
-
-    Compare two pairs of years and dekads,
-    that the first pair are greater than the
-    second pair.
-    """
-    return compare_dekads_lt(dekad1=dekad2, dekad2=dekad1)
-
-
-def compare_dekads_gte(
-    dekad1: Tuple[int, int], dekad2: Tuple[int, int]
-) -> bool:
-    """Is year1/dekad1 greater than or equal to year2/dekad2.
-
-    Compare two pairs of years and dekads,
-    that the first pair are greater than or
-    equal to the second pair.
-    """
-    return compare_dekads_lte(dekad1=dekad2, dekad2=dekad1)
-
-
-def expand_dekads(
-    dekad1: Tuple[int, int], dekad2: Tuple[int, int]
-) -> List[Tuple[int, int]]:
-    """Expand for all years/dekads between two dates.
-
-    Takes input year and dekads and returns a list
-    of year/dekad lists.
-    """
-    if compare_dekads_gt(dekad1, dekad2):
-        raise ValueError("`dekad1` must be less than or equal to `dekad2`.")
-
-    y1, d1 = dekad1
-    y2, d2 = dekad2
-    year_range = range(y1, y2 + 1)
-    dekad_range = range(1, 37)
-    date_combos = itertools.product(*[year_range, dekad_range])
-
-    def valid(y, d):
-        return not ((y == y1 and d < d1) or (y == y2 and d > d2))
-
-    return [(y, d) for y, d in date_combos if valid(y, d)]
+    return [x + i for i in range(y - x + 1)]

--- a/src/ochanticipy/utils/dates.py
+++ b/src/ochanticipy/utils/dates.py
@@ -66,15 +66,10 @@ def get_kalendar_date(
         date, str, Tuple[int, int], Dekad, Pentad, None
     ] = None,
 ) -> Union[Dekad, Pentad]:
-    """Calculate dekadal date from general input.
+    """Calculate kalendar date from general input.
 
-    Processes input ``input_date`` and returns two
-    values, the year and dekad. Input can be of
-    format ``datetime.date``, an ISO8601 date
-    string, an already calculated ``(year, dekad)``
-    format date, or ``None``. If ``None``,
-    ``default_date`` is returned. ``default_date``
-    can also be passed in the above formats.
+    Is used for both dekads and pentads coming from
+    kalendar.
     """
     if input_date is None and default_date is not None:
         input_date = default_date
@@ -98,6 +93,44 @@ def get_kalendar_date(
                 "of `(year, dekad)` format, or "
                 "ISO8601 date strings."
             ) from e
+
+
+def get_dekadal_date(
+    input_date: Union[date, str, Tuple[int, int], Dekad, None],
+    default_date: Union[date, str, Tuple[int, int], Dekad, None] = None,
+) -> Dekad:
+    """Calculate dekadal date from general input.
+
+    Processes input ``input_date`` and returns two
+    values, the year and dekad. Input can be of
+    format ``datetime.date``, an ISO8601 date
+    string, an already calculated ``(year, dekad)``
+    tuple, ``kalendar.Dekad`` object, or ``None``. If ``None``,
+    ``default_date`` is returned. ``default_date``
+    can also be passed in the above formats.
+    """
+    return get_kalendar_date(
+        kalendar_class=Dekad, input_date=input_date, default_date=default_date
+    )
+
+
+def get_pentadal_date(
+    input_date: Union[date, str, Tuple[int, int], Pentad, None],
+    default_date: Union[date, str, Tuple[int, int], Pentad, None] = None,
+) -> Pentad:
+    """Calculate kalendar date from general input.
+
+    Processes input ``input_date`` and returns two
+    values, the year and pentad. Input can be of
+    format ``datetime.date``, an ISO8601 date
+    string, an already calculated ``(year, pentad)``
+    tuple, ``kalendar.Pentad`` object, or ``None``. If ``None``,
+    ``default_date`` is returned. ``default_date``
+    can also be passed in the above formats.
+    """
+    return get_kalendar_date(
+        kalendar_class=Pentad, input_date=input_date, default_date=default_date
+    )
 
 
 @overload

--- a/tests/datasources/test_ndvi.py
+++ b/tests/datasources/test_ndvi.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from kalendar import Dekad
 from shapely.geometry import Polygon
 
 from ochanticipy import (
@@ -16,6 +17,7 @@ from ochanticipy import (
     UsgsNdviSmoothed,
     UsgsNdviYearDifference,
 )
+from ochanticipy.utils.dates import kalendar_range
 
 DATASOURCE_BASE_DIR = "usgs_ndvi"
 
@@ -34,7 +36,6 @@ def mock_ndvi(mock_country_config):
     }
 
     def _mock_ndvi(variable: str = "smoothed"):
-
         ndvi = instantiator[variable](
             country_config=mock_country_config,
             start_date=start_date,
@@ -244,10 +245,10 @@ def test_load_if_process_not_called(mock_ndvi):
         ndvi.load(feature_col="name")
 
 
-def test_fp_year_dekad():
+def test_fp_dekad():
     """Test that year and dekad extracted from FP."""
     fp = Path("ea2022_10pct.tif")
-    assert UsgsNdviPctMedian._fp_year_dekad(fp) == [2022, 10]
+    assert UsgsNdviPctMedian._fp_dekad(fp) == Dekad(2022, 10)
 
 
 def test_get_url(mock_ndvi):
@@ -265,7 +266,7 @@ def test_get_url(mock_ndvi):
 
 def test_process_dates_clobber_true(mock_determine_process_dates):
     """Test process dates clobbers properly."""
-    dps = [(2019, 36), (2020, 1), (2020, 2)]
+    dps = kalendar_range(x=Dekad(2019, 36), y=Dekad(2020, 2))
     test_dps, df = mock_determine_process_dates(
         clobber=True, dates_to_process=dps
     )
@@ -275,7 +276,7 @@ def test_process_dates_clobber_true(mock_determine_process_dates):
 
 def test_process_dates_clobber_false(mock_determine_process_dates):
     """Test process dates doesn't clobber unnecessarily."""
-    dps = [(2019, 36), (2020, 1), (2020, 2)]
+    dps = kalendar_range(x=Dekad(2019, 36), y=Dekad(2020, 2))
     test_dps, df = mock_determine_process_dates(
         clobber=False, dates_to_process=dps
     )
@@ -285,7 +286,7 @@ def test_process_dates_clobber_false(mock_determine_process_dates):
 
 def test_process_dates_clobber_true_additional(mock_determine_process_dates):
     """Test process dates clobbers properly."""
-    dps = [(2019, 35), (2019, 36), (2020, 1), (2020, 2), (2020, 3)]
+    dps = kalendar_range(x=Dekad(2019, 35), y=Dekad(2020, 3))
     test_dps, df = mock_determine_process_dates(
         clobber=True, dates_to_process=dps
     )
@@ -295,7 +296,7 @@ def test_process_dates_clobber_true_additional(mock_determine_process_dates):
 
 def test_process_dates_clobber_false_additional(mock_determine_process_dates):
     """Test process dates doesn't clobber unnecessarily."""
-    dps = [(2019, 35), (2019, 36), (2020, 1), (2020, 2), (2020, 3)]
+    dps = kalendar_range(x=Dekad(2019, 35), y=Dekad(2020, 3))
     test_dps, df = mock_determine_process_dates(
         clobber=False, dates_to_process=dps
     )

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -3,6 +3,7 @@
 from datetime import date, datetime
 
 import pytest
+from kalendar import Dekad, Pentad
 
 from ochanticipy.utils import dates
 
@@ -27,7 +28,7 @@ def test_get_date_value_error():
 
 def test_get_dekadal_date():
     """Tests get dekadal date."""
-    desired_dekad = (2013, 8)
+    desired_dekad = Dekad(2013, 8)
     desired_str = "2013-03-14"
     assert dates.get_dekadal_date(desired_str) == desired_dekad
     assert dates.get_dekadal_date(desired_dekad) == desired_dekad
@@ -46,44 +47,15 @@ def test_get_dekadal_date_value_error():
     with pytest.raises(ValueError):
         dates.get_dekadal_date("2020-01-1")
     with pytest.raises(ValueError):
-        dates.get_dekadal_date((20, 17))
+        dates.get_dekadal_date((2017, 37))
 
 
-def test_dekad_to_date():
-    """Test conversion from dekad to date."""
-    assert dates.dekad_to_date((2020, 1)) == date.fromisoformat("2020-01-01")
-    assert dates.dekad_to_date((2016, 20)) == date.fromisoformat("2016-07-11")
-    assert dates.dekad_to_date((2024, 36)) == date.fromisoformat("2024-12-21")
-
-
-def test_date_to_dekad():
-    """Test conversion from dekad to date."""
-    assert dates.date_to_dekad(date.fromisoformat("2020-01-09")) == (2020, 1)
-    assert dates.date_to_dekad(date.fromisoformat("2016-07-20")) == (2016, 20)
-    assert dates.date_to_dekad(date.fromisoformat("2024-12-31")) == (2024, 36)
-
-
-def test_compare_dekads():
-    """Test comparing dekads."""
-    dekad1 = (2019, 36)
-    dekad2 = (2020, 1)
-    assert dates.compare_dekads_gt(dekad2, dekad1)
-    assert dates.compare_dekads_gte(dekad2, dekad1)
-    assert dates.compare_dekads_lt(dekad1, dekad2)
-    assert dates.compare_dekads_lte(dekad1, dekad2)
-    assert dates.compare_dekads_gte(dekad2, dekad2)
-    assert dates.compare_dekads_lte(dekad2, dekad2)
-
-
-def test_expand_dekads():
+def test_kalendar_range():
     """Test expanding dekads."""
-    dekad1 = (2019, 33)
-    dekad2 = (2020, 3)
-    dekads = dates.expand_dekads(dekad1, dekad2)
-    assert len(dekads) == 7
-    assert dekads[0] == dekad1
-    assert dekads[6] == dekad2
-    assert dekads[4] == (2020, 1)
-    # error raised for reverse attempt
-    with pytest.raises(ValueError):
-        dates.expand_dekads(dekad2, dekad1)
+    pentad1 = Pentad(2019, 70)
+    pentad2 = Pentad(2020, 3)
+    pentads = dates.kalendar_range(x=pentad1, y=pentad2)
+    assert len(pentads) == 7
+    assert pentads[0] == pentad1
+    assert pentads[6] == pentad2
+    assert pentads[4] == Pentad(2020, 1)


### PR DESCRIPTION
Implements #106.

I brought in the `kalendar` library into our `dates.py` module. I think we still need our own module to allow for the broader implementation of the user inputted ISO dates/strings and wider work, but has made the implementation much simpler.

This has all been used on the backend for NDVI. However, I made the decision NOT to include the dekad class on the end output. I think that would make it confusing for end users if they potentially saw classes they weren't familiar with or had no desire to use, so rather kept the format of output files having year, dekad, and date columns.

Look forward to your review and thoughts!