### PR TITLE
Hotfix/raster doctests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Fixed
 fixed to work for `rioxarray` methods
 - USGS NDVI documentation was updated to remove dead links
 and improve users ability to use the historical data
+- pandas ``Index`` used in raster module docstrings in lieu of
+the now deprecated ``Int64Index``
 
 
 [1.0.1] - 2023-02-03

--- a/src/ochanticipy/utils/raster.py
+++ b/src/ochanticipy/utils/raster.py
@@ -258,9 +258,9 @@ class OapRasterMixin:
         ... )
         >>> da.oap.invert_coordinates(inplace=True)
         >>> da.get_index("lon")
-        Int64Index([67, 68, 69, 70], dtype='int64', name='lon')
+        Index([67, 68, 69, 70], dtype='int64', name='lon')
         >>> da.get_index("lat")
-        Int64Index([90, 89, 88, 87], dtype='int64', name='lat')
+        Index([90, 89, 88, 87], dtype='int64', name='lat')
         """
         data_obj = self._get_obj_oap(inplace=inplace)
         lon_inv, lat_inv = self._check_coords_inverted()
@@ -346,11 +346,11 @@ class OapRasterMixin:
         ... )
         >>> ds_inv = ds.oap.change_longitude_range()
         >>> ds_inv.get_index("lon")
-        Int64Index([-161, 0, 5, 120], dtype='int64', name='lon')
+        Index([-161, 0, 5, 120], dtype='int64', name='lon')
         >>> # invert coordinates back to original, in place
         >>> ds_inv.oap.change_longitude_range(to_180_range=False, inplace=True)
         >>> ds_inv.get_index("lon")
-        Int64Index([0, 5, 120, 199], dtype='int64', name='lon')
+        Index([0, 5, 120, 199], dtype='int64', name='lon')
         """
         data_obj = self._get_obj_oap(inplace=inplace)
 


### PR DESCRIPTION
Simple fix to raster doctests addressing the failing tests. The tests are not failing due to any functional issues, just that the docstrings reference ``Int64Index`` from pandas which has now been r[emoved and replaced by ``Index``](https://stackoverflow.com/questions/71083866/pandas-int64index-fix-for-futurewarning), so the doctests were failing. Because of this, just figured we can release alongside the rest of develop since many changes are coming, rather than hot fixing directly to main.